### PR TITLE
Re-add the "extend" argument

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,6 +1,6 @@
 [
 	{
-		"keys": ["ctrl+shift+s"], "command": "select_until"
+		"keys": ["ctrl+shift+s"], "command": "select_until", "args": {"extend": true}
 	},
 	{
 		"keys": ["ctrl+shift+r"], "command": "reverse_select"

--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@ Fill a void in your Sublime Text multiple selection capabilities! This plugin al
 ## Usage
 `ctrl+shift+s` pulls up an input field, where you can type:
 
- - `search term` or `[search term]`: for each selection, select up to and including the first occurrence of the search term.
- - `/regex search/`: select through the first occurrence of the regex.
- - `{character count}`: select forward the given number of characters.
- - `-[search term]`: select backwards up to and including the search term.
+ - `search term` or `[search term]`: extend each selection up through the first occurrence of the search term.
+ - `/regex search/`: extend through the first occurrence of the regex.
+ - `{character count}`: extend forward the given number of characters.
+ - `-[search term]`: extend backwards up to and including the search term.
  - `-/regex/`: backwards regex.
- - `-{character count}`: select backwards a certain number of characters (`{-count}` works too).
+ - `-{character count}`: extend backwards a certain number of characters (`{-count}` works too).
 
 `ctrl+shift+r`: reverse all selections (so if the insertion point is at the end of the selection, it is moved to the beginning, and vice versa).
+
+You can also add your own keybinding and set the "extend" argument to false to just move the selections instead of extending them.

--- a/select-until.py
+++ b/select-until.py
@@ -3,6 +3,13 @@ from sublime import Region
 
 import re
 
+# In ST3, view.find returns Region(-1,-1) if there are no occurrences.
+# In ST2, however, it returns None, so we have to check for that.
+def safe_end(region):
+	if region is None:
+		return -1
+	return region.end()
+
 def on_done(view, extend):
 	if extend:
 		newSels = view.get_regions("select-until-extended")
@@ -22,7 +29,7 @@ def find_matching_point(view, sel, selector):
 
 	result = rSelector.search(selector)
 
-	if result is None: return view.find(selector, sel.end(), sublime.LITERAL).end()
+	if result is None: return safe_end(view.find(selector, sel.end(), sublime.LITERAL))
 
 	groups = result.groups()
 	isReverse = (groups[0] == "-")
@@ -35,8 +42,8 @@ def find_matching_point(view, sel, selector):
 		else: return sel.end() + num
 
 	if not isReverse:
-		if regex is not None: return view.find(regex, sel.end()).end()
-		else: return view.find(chars, sel.end(), sublime.LITERAL).end()
+		if regex is not None: return safe_end(view.find(regex, sel.end()))
+		else: return safe_end(view.find(chars, sel.end(), sublime.LITERAL))
 
 	if regex is not None: regions = view.find_all(regex)
 	else: regions = view.find_all(chars, sublime.LITERAL)

--- a/select-until.py
+++ b/select-until.py
@@ -3,8 +3,12 @@ from sublime import Region
 
 import re
 
-def on_done(view):
-	newSels = view.get_regions("select-until")
+def on_done(view, extend):
+	if extend:
+		newSels = view.get_regions("select-until-extended")
+	else:
+		newSels = view.get_regions("select-until")
+	view.erase_regions("select-until-extended")
 	view.erase_regions("select-until")
 
 	sels = view.sel()
@@ -13,12 +17,12 @@ def on_done(view):
 		sels.add(sel)
 
 rSelector = re.compile("^(-?)(?:\{(-?\d+)\}|\[(.+)\]|/(.+)/)$")
-def find_matching_region(view, sel, selector):
-	if selector == "": return None
+def find_matching_point(view, sel, selector):
+	if selector == "": return -1
 
 	result = rSelector.search(selector)
 
-	if result is None: return view.find(selector, sel.end(), sublime.LITERAL)
+	if result is None: return view.find(selector, sel.end(), sublime.LITERAL).end()
 
 	groups = result.groups()
 	isReverse = (groups[0] == "-")
@@ -27,33 +31,40 @@ def find_matching_region(view, sel, selector):
 	regex = groups[3]
 
 	if num is not None:
-		if isReverse: return Region(sel.begin() - num, sel.end())
-		else: return Region(sel.begin(), sel.end() + num)
+		if isReverse: return sel.begin() - num
+		else: return sel.end() + num
 
 	if not isReverse:
-		if regex is not None: return view.find(regex, sel.end())
-		else: return view.find(chars, sel.end(), sublime.LITERAL)
+		if regex is not None: return view.find(regex, sel.end()).end()
+		else: return view.find(chars, sel.end(), sublime.LITERAL).end()
 
 	if regex is not None: regions = view.find_all(regex)
 	else: regions = view.find_all(chars, sublime.LITERAL)
 
 	for region in reversed(regions):
 		if region.end() <= sel.begin():
-			return Region(region.begin(), sel.end())
+			return region.begin()
 
 def on_change(view, oriSels, selector):
+	extendedSels = []
 	newSels = []
 	for sel in oriSels:
-		regFind = find_matching_region(view, sel, selector)
+		point = find_matching_point(view, sel, selector)
 
-		if regFind is None: continue
+		if point is -1: point = sel.b #try to keep this selection the same
 
-		regExpand = sel.cover(regFind)
-		newSels.append(regExpand)
+		region = Region(point, point)
 
+		extendedSel = sel.cover(region)
+		extendedSels.append(extendedSel)
+
+		newSels.append(region)
+
+	view.add_regions("select-until-extended", extendedSels, "comment", "", sublime.DRAW_OUTLINED)
 	view.add_regions("select-until", newSels, "comment", "", sublime.DRAW_OUTLINED)
 
 def on_cancel(view, oriSels):
+	view.erase_regions("select-until-extended")
 	view.erase_regions("select-until")
 
 	sels = view.sel()
@@ -63,14 +74,14 @@ def on_cancel(view, oriSels):
 
 class SelectUntilCommand(sublime_plugin.TextCommand):
 
-	def run(self, edit):
+	def run(self, edit, extend):
 		view = self.view
 		oriSels = [ sel for sel in view.sel() ]
 
 		view.window().show_input_panel(
 			"Select Until Next -- chars or [chars] or {count} or /regex/.  Use minus (-) to reverse search:",
 			"",
-			lambda selector: on_done(view),
+			lambda selector: on_done(view, extend),
 			lambda selector: on_change(view, oriSels, selector),
 			lambda : on_cancel(view, oriSels)
 		)

--- a/select-until.py
+++ b/select-until.py
@@ -44,6 +44,7 @@ def find_matching_point(view, sel, selector):
 	for region in reversed(regions):
 		if region.end() <= sel.begin():
 			return region.begin()
+	return -1
 
 def on_change(view, oriSels, selector):
 	extendedSels = []


### PR DESCRIPTION
This lets you distinguish between moving the selections or extending them. Tested in both ST2 and ST3.
