### PR TITLE
Swap directions by hitting the shortcut a second time

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Fill a void in your Sublime Text multiple selection capabilities! This plugin al
 
 ## Usage
 
-- <kbd>ctrl/alt</kbd> + <kbd>shift</kbd> + <kbd>s</kbd>: pulls up an input field, where you can type:
+- <kbd>ctrl/alt</kbd> + <kbd>shift</kbd> + <kbd>s</kbd> once: pulls up an input field, where you can type:
 
 	- `search term` or `[search term]`: for each selection, select up to and including the first occurrence of the search term.
 	- `/regex search/`: select through the first occurrence of the regex.
@@ -12,6 +12,8 @@ Fill a void in your Sublime Text multiple selection capabilities! This plugin al
 	- `-[search term]`: select backwards up to and including the search term.
 	- `-/regex/`: backwards regex.
 	- `-{character count}`: select backwards a certain number of characters (`{-count}` works too).
+
+- <kbd>ctrl/alt</kbd> + <kbd>shift</kbd> + <kbd>s</kbd> a second time: reverse the search direction.
 
 - <kbd>ctrl/alt</kbd> + <kbd>shift</kbd> + <kbd>r</kbd>: reverse all selections (so if the insertion point is at the end of the selection, it is moved to the beginning, and vice versa).
 

--- a/select-until.py
+++ b/select-until.py
@@ -30,18 +30,16 @@ def on_done(view, extend):
 	SelectUntilCommand.prevSelector = SelectUntilCommand.temp or SelectUntilCommand.prevSelector
 	clean_up(view)
 
-rSelector = re.compile("^(-?)(?:\{(-?\d+)\}|\[(.+)\]|/(.+)/)$")
+rSelector = re.compile("^(-?)(?:\{(-?\d+)\}|\[(.+)\]|/(.+)/|(.*))$")
 def find_matching_point(view, sel, selector):
 	if selector == "": return -1
 
 	result = rSelector.search(selector)
 
-	if result is None: return safe_end(view.find(selector, sel.end(), sublime.LITERAL))
-
 	groups = result.groups()
 	isReverse = (groups[0] == "-")
 	num = int(groups[1]) if groups[1] is not None else None
-	chars = groups[2]
+	chars = groups[2] or groups[4]
 	regex = groups[3]
 
 	if num is not None:

--- a/select-until.py
+++ b/select-until.py
@@ -42,20 +42,20 @@ def find_matching_point(view, sel, selector):
 	chars = groups[2] or groups[4]
 	regex = groups[3]
 
-	if num is not None:
-		if isReverse: return sel.begin() - num
-		else: return sel.end() + num
-
 	if not isReverse:
-		if regex is not None: return safe_end(view.find(regex, sel.end()))
+		if num is not None: return sel.end() + num
+		elif regex is not None: return safe_end(view.find(regex, sel.end()))
 		else: return safe_end(view.find(chars, sel.end(), sublime.LITERAL))
 
-	if regex is not None: regions = view.find_all(regex)
-	else: regions = view.find_all(chars, sublime.LITERAL)
+	else:
+		if num is not None: return sel.begin() - num
+		elif regex is not None: regions = view.find_all(regex)
+		else: regions = view.find_all(chars, sublime.LITERAL)
 
-	for region in reversed(regions):
-		if region.end() <= sel.begin():
-			return region.begin()
+		for region in reversed(regions):
+			if region.end() <= sel.begin():
+				return region.begin()
+
 	return -1
 
 def on_change(view, oriSels, selector, extend):

--- a/select-until.py
+++ b/select-until.py
@@ -107,11 +107,13 @@ class SelectUntilCommand(sublime_plugin.TextCommand):
 		view = self.view.window().active_view_in_group(self.view.window().active_group())
 
 		if SelectUntilCommand.running:
-			SelectUntilCommand.searchForward = not SelectUntilCommand.searchForward
+			if SelectUntilCommand.extend == extend:
+				SelectUntilCommand.searchForward = not SelectUntilCommand.searchForward
 			SelectUntilCommand.prevSelector = SelectUntilCommand.temp
 		else:
 			SelectUntilCommand.searchForward = True
 		SelectUntilCommand.running = True
+		SelectUntilCommand.extend = extend
 
 		#We have to use set_timeout here; otherwise the quick panel doesn't actually
 		#update correctly if we open it a second time. Seems to be a bug in Sublime.

--- a/select-until.py
+++ b/select-until.py
@@ -10,14 +10,16 @@ def safe_end(region):
 		return -1
 	return region.end()
 
+def clean_up(view):
+	view.erase_regions("select-until-extended")
+	view.erase_regions("select-until")
+	view.erase_regions("select-until-originals")
+
 def on_done(view, extend):
 	if extend:
 		newSels = view.get_regions("select-until-extended")
 	else:
 		newSels = view.get_regions("select-until")
-	view.erase_regions("select-until-extended")
-	view.erase_regions("select-until")
-	view.erase_regions("select-until-originals")
 
 	sels = view.sel()
 	sels.clear()
@@ -25,6 +27,7 @@ def on_done(view, extend):
 		sels.add(sel)
 
 	SelectUntilCommand.prevSelector = SelectUntilCommand.temp or SelectUntilCommand.prevSelector
+	clean_up(view)
 
 rSelector = re.compile("^(-?)(?:\{(-?\d+)\}|\[(.+)\]|/(.+)/)$")
 def find_matching_point(view, sel, selector):
@@ -79,14 +82,12 @@ def on_change(view, oriSels, selector, extend):
 		view.add_regions("select-until", newSels, "entity", "", sublime.DRAW_EMPTY)
 
 def on_cancel(view, oriSels):
-	view.erase_regions("select-until-extended")
-	view.erase_regions("select-until")
-	view.erase_regions("select-until-originals")
-
 	sels = view.sel()
 	sels.clear()
 	for sel in oriSels:
 		sels.add(sel)
+
+	clean_up(view)
 
 class SelectUntilCommand(sublime_plugin.TextCommand):
 	temp = ""

--- a/select-until.py
+++ b/select-until.py
@@ -107,7 +107,8 @@ class SelectUntilCommand(sublime_plugin.TextCommand):
 		view = self.view.window().active_view_in_group(self.view.window().active_group())
 
 		if SelectUntilCommand.running:
-			if SelectUntilCommand.extend == extend:
+			#Don't switch direction if the panel is open but unfocussed
+			if view != self.view and SelectUntilCommand.extend == extend:
 				SelectUntilCommand.searchForward = not SelectUntilCommand.searchForward
 			SelectUntilCommand.prevSelector = SelectUntilCommand.temp
 		else:

--- a/select-until.py
+++ b/select-until.py
@@ -17,6 +17,7 @@ def on_done(view, extend):
 		newSels = view.get_regions("select-until")
 	view.erase_regions("select-until-extended")
 	view.erase_regions("select-until")
+	view.erase_regions("select-until-originals")
 
 	sels = view.sel()
 	sels.clear()
@@ -55,7 +56,7 @@ def find_matching_point(view, sel, selector):
 			return region.begin()
 	return -1
 
-def on_change(view, oriSels, selector):
+def on_change(view, oriSels, selector, extend):
 	SelectUntilCommand.temp = selector
 	extendedSels = []
 	newSels = []
@@ -71,12 +72,16 @@ def on_change(view, oriSels, selector):
 
 		newSels.append(region)
 
-	view.add_regions("select-until-extended", extendedSels, "comment", "", sublime.DRAW_OUTLINED)
-	view.add_regions("select-until", newSels, "comment", "", sublime.DRAW_OUTLINED)
+	view.add_regions("select-until-originals", oriSels, "comment", "", sublime.DRAW_EMPTY)
+	if extend:
+		view.add_regions("select-until-extended", extendedSels, "entity", "", sublime.DRAW_OUTLINED)
+	else:
+		view.add_regions("select-until", newSels, "entity", "", sublime.DRAW_EMPTY)
 
 def on_cancel(view, oriSels):
 	view.erase_regions("select-until-extended")
 	view.erase_regions("select-until")
+	view.erase_regions("select-until-originals")
 
 	sels = view.sel()
 	sels.clear()
@@ -95,7 +100,7 @@ class SelectUntilCommand(sublime_plugin.TextCommand):
 			"Select Until Next -- chars or [chars] or {count} or /regex/.  Use minus (-) to reverse search:",
 			SelectUntilCommand.prevSelector,
 			lambda selector: on_done(view, extend),
-			lambda selector: on_change(view, oriSels, selector),
+			lambda selector: on_change(view, oriSels, selector, extend),
 			lambda : on_cancel(view, oriSels)
 		)
 		v.sel().clear()


### PR DESCRIPTION
I love this plugin, but I find it searching backwards to be more difficult than I'd like - I have to add a minus, and square brackets, etc. These changes (which include the commit in https://github.com/xavi-/sublime-selectuntil/pull/7) let you switch the search direction back and forth just by hitting the shortcut again.
Also included are some display fixes that work around bugs in Sublime's input panel (commit 7d04bda).
