### PR TITLE
Add Command Palette support

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,0 +1,12 @@
+[
+    {
+        "caption": "Select Until",
+        "command": "select_until",
+        "args": { "extend": true }
+    },
+    {
+        "caption": "Select Until - Reverse",
+        "command": "reverse_select",
+        "args": { "extend": true }
+    }
+]


### PR DESCRIPTION
Added support for Sublime Text's command palette. This makes it possible to use a command by searching rather than having to remember the shortcut.

See http://docs.sublimetext.info/en/latest/reference/command_palette.html for more info.